### PR TITLE
More pass-through fixes

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -127,6 +127,7 @@ fatal msg = hPutStrLn stderr $ "ghc-parmake: " ++ msg
 flagsConflictingWithM :: [String]
 flagsConflictingWithM = [ "--show-iface", "-E", "-C", "-S", "-c"
                         , "--interactive", "-e", "--abi-hash"
+                        , "--info"
                         ]
 
 -- Program entry point.


### PR DESCRIPTION
Playing with [ghc-make](https://github.com/ndmitchell/ghc-make), I found two more situations when arguments are not passed through when they should.

I also cleaned up the relevant part.
