### PR TITLE
Minor fixes and a solution to the external-dependencies problem

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -112,10 +112,10 @@ usage =
   "-V               - Print version information.\n" ++
   "\nOther options are passed to GHC unmodified.\n"
 
-guessOutputFilename :: Maybe FilePath -> [FilePath] -> FilePath
-guessOutputFilename (Just n) _  = n
-guessOutputFilename Nothing [n] = dropExtension n
-guessOutputFilename Nothing _   = "a.out"
+guessOutputFilename :: Maybe FilePath -> [FilePath] -> Maybe FilePath
+guessOutputFilename (Just n) _  = Just n
+guessOutputFilename Nothing [n] = Just (dropExtension n)
+guessOutputFilename Nothing _   = Nothing
 
 fatal :: String -> IO ()
 fatal msg = hPutStrLn stderr $ "ghc-parmake: " ++ msg

--- a/Main.hs
+++ b/Main.hs
@@ -128,15 +128,14 @@ fatal msg = hPutStrLn stderr $ "ghc-parmake: " ++ msg
 flagsConflictingWithM :: [String]
 flagsConflictingWithM =
   -- "Help and verbosity options"
-  [ "-?"
-  , "--help"
-  , "-V"
+  [ "?"
   , "--supported-extensions"
   , "--supported-languages"
   , "--info"
   , "--version"
   , "--numeric-version"
   , "--print-libdir"
+  -- -V and --help are not included here because this program uses them
 
   -- "Which phases to run"
   , "-E"
@@ -167,10 +166,10 @@ main =
      -- Cases in which we just want to pass on all arguments to GHC and be
      -- as transparent as possible:
      --
-     -- * --version or --numeric-version is used
+     -- * --numeric-version is used
      --   (e.g. cabal does this to determine the GHC version)
      -- * No input files are given
-     -- * An option conflicting with "-M" is given (we include --version here)
+     -- * An option conflicting with "-M" is given
      when (null files || any (`elem` ghcArgs) flagsConflictingWithM) $
        exitWith =<< runProcess defaultOutputHooks Nothing
                                (ghcPath args) (ghcArgs ++ files)

--- a/Main.hs
+++ b/Main.hs
@@ -187,7 +187,7 @@ main =
 
      when (null files) $ passToGhc
 
-     debug' v "Running ghc -M..."
+     debug' v "Running ghc -M (twice)..."
      deps <- Parse.getModuleDeps v (ghcPath args) ghcArgs files
      when (null deps) $ do
       hPutStrLn stderr "ghc-parmake: no dependencies"

--- a/ghc-parmake.cabal
+++ b/ghc-parmake.cabal
@@ -45,6 +45,7 @@ Library
                         GHC.ParMake.Common
                         GHC.ParMake.Engine
                         GHC.ParMake.Parse
+                        GHC.ParMake.Types
                         GHC.ParMake.Util
   Other-modules:        Distribution.Compat.ReadP
   Hs-source-dirs:       src

--- a/src/GHC/ParMake/BuildPlan.hs
+++ b/src/GHC/ParMake/BuildPlan.hs
@@ -19,7 +19,7 @@ import Data.Graph (Graph)
 import Data.Function (on)
 import Data.IntMap (IntMap)
 import Data.IntSet (IntSet)
-import Data.List (find, groupBy, sortBy)
+import Data.List (find, groupBy, sort, sortBy)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Ord (comparing)
 import System.FilePath (replaceExtension, takeExtension)
@@ -154,7 +154,8 @@ new deps = BuildPlan graph graphRev targetIdToVertex vertexToTargetId
 -- | Given a list of (target, dependency) pairs, produce a list of Targets.
 depsToTargets :: [(TargetId, TargetId)] -> [Target]
 depsToTargets = map (\l -> mkModuleTarget (fst . head $ l) (map snd l)) .
-                groupBy ((==) `on` fst)
+                groupBy ((==) `on` fst) .
+                sort -- sort to not assume Makefile is not in order
   where
     mkModuleTarget tId tDeps = assert check (Target tId tSrc tDeps)
       where

--- a/src/GHC/ParMake/BuildPlan.hs
+++ b/src/GHC/ParMake/BuildPlan.hs
@@ -6,7 +6,7 @@ module GHC.ParMake.BuildPlan
        (new, ready, building, completed, size
        , numCompleted, markCompleted
        , markReadyAsBuilding, numBuilding, hasBuilding
-       , BuildPlan, Target, TargetId, targetId, depends, source, object, objects)
+       , BuildPlan, Target, TargetId, targetId, allDepends, source, object, objects)
        where
 
 import qualified Data.Array as Array
@@ -19,15 +19,21 @@ import Data.Graph (Graph)
 import Data.Function (on)
 import Data.IntMap (IntMap)
 import Data.IntSet (IntSet)
-import Data.List (find, groupBy, sort, sortBy)
+
+import Data.List (find, sortBy)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Ord (comparing)
 import System.FilePath (replaceExtension, takeExtension)
 
+import GHC.ParMake.Types (Dep(..))
+
 type TargetId = FilePath
+type ExternalDep = FilePath
 data Target = Target TargetId  -- ^ Target (e.g. 'Main.o')
               FilePath         -- ^ Source (e.g. 'Main.hs')
               [TargetId]       -- ^ Dependencies (e.g. 'A.hi', 'B.hi')
+              [ExternalDep]    -- ^ External dependencies (e.g. from the system: '/usr/local/ghc/ghc-7.6.3/lib/ghc-7.6.3/base-4.6.0.1/Prelude.hi'
+                               --                               or packages:     'cabal-dev/lib/mypackage-0.0.0.1/ghc-7.6.3/Module.hi')
             deriving (Show)
 
 instance Eq Target where
@@ -35,23 +41,31 @@ instance Eq Target where
 
 -- | Given a Target, return its ID.
 targetId :: Target -> TargetId
-targetId (Target tId _ _) = tId
+targetId (Target tId _ _ _) = tId
 
--- | Given a Target, return its dependencies.
+-- | Given a Target, return its dependencies (excluding external ones).
 depends :: Target -> [TargetId]
-depends (Target _ _ deps) = deps
+depends (Target _ _ deps _) = deps
+
+-- | Given a Target, return its external dependencies.
+externalDepends :: Target -> [TargetId]
+externalDepends (Target _ _ _ externalDeps) = externalDeps
+
+-- | Given a Target, return all its dependencies (home + external).
+allDepends :: Target -> [TargetId]
+allDepends t = depends t ++ externalDepends t
 
 -- | Given a Target, return the name of the source file from which it can be
 -- produced.
 source :: Target -> FilePath
-source (Target _ tSrc _) = tSrc
+source (Target _ tSrc _ _) = tSrc
 
 -- | Given a Target, return the name of the object file produced from it that
 -- should be fed to the linker.
 object :: Target -> Maybe FilePath
-object (Target tId _ _) = case takeExtension tId
-                          of ".o-boot" -> Nothing
-                             _         -> Just tId
+object (Target tId _ _ _) = case takeExtension tId
+                            of ".o-boot" -> Nothing
+                               _         -> Just tId
 
 -- | Given a BuildPlan, return the list of object files for all completed
 -- targets.
@@ -97,7 +111,7 @@ instance Show BuildPlan where
 
 -- | Create a new BuildPlan from a list of (target, dependency) pairs. This is
 -- mostly a copy of Distribution.Client.PackageIndex.dependencyGraph.
-new :: [(TargetId, TargetId)] -> BuildPlan
+new :: [Dep] -> BuildPlan
 new deps = BuildPlan graph graphRev targetIdToVertex vertexToTargetId
            numDepsMap readySet buildingSet
   where
@@ -124,7 +138,9 @@ new deps = BuildPlan graph graphRev targetIdToVertex vertexToTargetId
       where
         -- Each target has an additional dependency on a '.hs' file which is not
         -- in the graph.
-        countNumDeps = subtract 1 . length . depends
+        countNumDeps t = case length (depends t) of
+          n | n > 0 -> n - 1
+          _         -> error "BuildPlan.countNumDeps: BUG: A target should never have 0 dependencies"
 
     -- TODO: It is possible to create a BuildPlan that is non-empty, but has
     --       no buildable parts and thus is stuck (e.g. when all targets
@@ -134,7 +150,7 @@ new deps = BuildPlan graph graphRev targetIdToVertex vertexToTargetId
                . zip [0..] $ targets
       where hasSingleSourceDep (_,t) = case depends t of
               -- TODO: This invariant should be enforced everywhere.
-              []  -> error "BuildPlan: BUG: A target should never have 0 dependencies"
+              []  -> error "BuildPlan.hasSingleSourceDep: BUG: A target should never have 0 dependencies"
               [d] -> (takeExtension d) `elem` sourceExts
               _   -> False
     buildingSet = IntSet.empty
@@ -153,20 +169,19 @@ new deps = BuildPlan graph graphRev targetIdToVertex vertexToTargetId
         GT -> binarySearch (mid+1) b key
       where mid = (a + b) `div` 2
 
--- | Given a list of (target, dependency) pairs, produce a list of Targets.
-depsToTargets :: [(TargetId, TargetId)] -> [Target]
-depsToTargets = map (\l -> mkModuleTarget (fst . head $ l) (map snd l)) .
-                groupBy ((==) `on` fst) .
-                sort -- sort to not assume Makefile is not in order
+-- | Given a list of (target, [dependency]), perform some checks and produce
+-- a list of build plan targets.
+depsToTargets :: [Dep] -> [Target]
+depsToTargets = map mkModuleTarget
   where
-    mkModuleTarget tId tDeps = assert check (Target tId tSrc tDeps)
+    mkModuleTarget (Dep t intDeps extDeps) = assert check (Target t tSrc intDeps extDeps)
       where
         tSrc = fromMaybe (error "No source file in dependencies!")
-               $ find ((`elem` sourceExts). takeExtension) tDeps
+               $ find ((`elem` sourceExts). takeExtension) intDeps
 
-        check = (takeExtension tId `elem` objExts)
-                && (length tDeps == 1
-                    || or [ takeExtension d `elem` interfaceExts | d <- tDeps ])
+        check = (takeExtension t `elem` objExts)
+                && (length intDeps == 1
+                    || or [ takeExtension d `elem` interfaceExts | d <- intDeps ])
 
 -- | Total number of targets in the BuildPlan.
 size :: BuildPlan -> Int

--- a/src/GHC/ParMake/BuildPlan.hs
+++ b/src/GHC/ParMake/BuildPlan.hs
@@ -133,6 +133,8 @@ new deps = BuildPlan graph graphRev targetIdToVertex vertexToTargetId
     readySet = IntSet.fromList . map fst . filter hasSingleSourceDep
                . zip [0..] $ targets
       where hasSingleSourceDep (_,t) = case depends t of
+              -- TODO: This invariant should be enforced everywhere.
+              []  -> error "BuildPlan: BUG: A target should never have 0 dependencies"
               [d] -> (takeExtension d) `elem` sourceExts
               _   -> False
     buildingSet = IntSet.empty

--- a/src/GHC/ParMake/BuildPlan.hs
+++ b/src/GHC/ParMake/BuildPlan.hs
@@ -126,6 +126,10 @@ new deps = BuildPlan graph graphRev targetIdToVertex vertexToTargetId
         -- in the graph.
         countNumDeps = subtract 1 . length . depends
 
+    -- TODO: It is possible to create a BuildPlan that is non-empty, but has
+    --       no buildable parts and thus is stuck (e.g. when all targets
+    --       have more than a single dependency).
+    --       We should raise some error when that happens.
     readySet = IntSet.fromList . map fst . filter hasSingleSourceDep
                . zip [0..] $ targets
       where hasSingleSourceDep (_,t) = case depends t of

--- a/src/GHC/ParMake/Engine.hs
+++ b/src/GHC/ParMake/Engine.hs
@@ -92,7 +92,7 @@ workerThread outHooks verbosity totNum ghcPath ghcArgs files wch cch
     buildModule curNum target =
       do let tId   = BuildPlan.targetId target
          let tSrc  = BuildPlan.source target
-         let tDeps = BuildPlan.depends target
+         let tDeps = BuildPlan.allDepends target
          let tName = slashesToDots . dropExtension $ tSrc
          let msg = "[" ++ show curNum ++ " of "++ totNum ++ "] Compiling "
                    ++ tName

--- a/src/GHC/ParMake/Engine.hs
+++ b/src/GHC/ParMake/Engine.hs
@@ -4,7 +4,7 @@ module GHC.ParMake.Engine
        where
 
 import Control.Concurrent (forkIO, newChan, readChan, writeChan, Chan)
-import Control.Monad (foldM, forever, forM_, when)
+import Control.Monad (foldM, forever, forM_)
 import System.Exit (ExitCode(..))
 import System.FilePath (dropExtension)
 
@@ -99,12 +99,10 @@ workerThread outHooks verbosity totNum ghcPath ghcArgs files wch cch
                    ++ replicate (16 - length tName) ' '
                    ++ " ( " ++ tSrc ++ ", " ++ tId ++ " )\n"
          isUpToDate <- upToDateCheck tId tDeps
-         if not isUpToDate
-           then
-           do noticeRaw outHooks verbosity msg
-              runGHC ("-c":tSrc:ghcArgs)
-           else
-           return ExitSuccess
+         if isUpToDate
+           then return ExitSuccess
+           else do noticeRaw outHooks verbosity msg
+                   runGHC ("-c":tSrc:ghcArgs)
 
     buildProgram :: FilePath -> IO ExitCode
     buildProgram outputFilename =
@@ -113,11 +111,12 @@ workerThread outHooks verbosity totNum ghcPath ghcArgs files wch cch
 -- One-way worker -> controller communication.
 data ControlMessage = ModuleCompiled Target | BuildCompleted
                     | CompileFailed Target ExitCode | BuildFailed ExitCode
+                    deriving (Show)
 type ControlChan = Chan ControlMessage
 
-controlThread :: BuildPlan -> FilePath -> ControlChan -> WorkerChan
+controlThread :: BuildPlan -> Maybe FilePath -> ControlChan -> WorkerChan
                  -> IO ExitCode
-controlThread p outputFilename cch wch =
+controlThread p mOutputFilename cch wch =
   do let rdy = BuildPlan.ready p
      -- Give worker threads initial tasks.
      curNum <- postTasks rdy 1
@@ -143,10 +142,28 @@ controlThread p outputFilename cch wch =
                 let rdy   = BuildPlan.ready plan'
                 curNum'  <- postTasks rdy curNum
                 let plan'' = BuildPlan.markReadyAsBuilding plan'
-                when (null rdy && BuildPlan.numBuilding plan'' == 0)
-                  (writeChan wch (BuildProgram outputFilename
-                                  $ BuildPlan.objects plan''))
-                go plan'' curNum'
+
+                -- Check if there is more to do.
+                if (null rdy && BuildPlan.numBuilding plan'' == 0)
+
+                  -- All modules are done.
+                  then
+                    -- Do we want to build an executable?
+                    -- If yes, queue this as the last thing to do before shutting down.
+                    case mOutputFilename of
+                      Nothing             -> return ExitSuccess
+                      Just outputFilename -> do
+                        writeChan wch $ BuildProgram outputFilename
+                                                     (BuildPlan.objects plan'')
+                        -- Wait for the response to BuildProgram.
+                        -- It must only be build success or failure.
+                        buildProgramMsg <- readChan cch
+                        case buildProgramMsg of
+                          BuildFailed c  -> return c
+                          BuildCompleted -> return ExitSuccess
+                          x              -> error $ "GHC.ParMake.Engine.controlThread: Unexpected BuildProgram response: " ++ show x
+
+                  else go plan'' curNum'
 
            CompileFailed t c -> waitAndExit (BuildPlan.markCompleted plan t) c
 
@@ -176,9 +193,9 @@ controlThread p outputFilename cch wch =
 
 -- | Given a BuildPlan, perform the compilation.
 compile :: Verbosity -> BuildPlan -> Int
-           -> FilePath -> [String] -> [FilePath] -> FilePath
+           -> FilePath -> [String] -> [FilePath] -> Maybe FilePath
            -> IO ExitCode
-compile verbosity plan numJobs ghcPath ghcArgs files outputFilename =
+compile verbosity plan numJobs ghcPath ghcArgs files mOutputFilename =
   do
     -- Init comm. channels
     workerChan  <- newChan
@@ -196,7 +213,10 @@ compile verbosity plan numJobs ghcPath ghcArgs files outputFilename =
     _ <- ($) forkIO $ logThread logChan
 
     -- Start the control thread.
-    controlThread plan outputFilename controlChan workerChan
+    controlThread plan mOutputFilename controlChan workerChan
+
+    -- Note that we don't explicitly shut down the worker threads;
+    -- the runtime kills them when the main thread exits.
   where
     totNum :: String
     totNum = show $ BuildPlan.size plan

--- a/src/GHC/ParMake/Parse.hs
+++ b/src/GHC/ParMake/Parse.hs
@@ -1,16 +1,24 @@
+{-# LANGUAGE TupleSections #-}
+
 -- Parsing.
 
-module GHC.ParMake.Parse (getModuleDeps)
+module GHC.ParMake.Parse (getModuleDeps, depsListToDeps)
        where
 
+import Control.Concurrent
+import Control.Monad
 import Data.Char (isAlphaNum, isSpace)
 import Data.Functor ((<$>))
+import Data.Map (Map)
+import qualified Data.Map as Map
 import Data.Maybe (catMaybes)
+import qualified Data.Set as Set
 import System.Exit (ExitCode(..))
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 
 import Distribution.Compat.ReadP
+import GHC.ParMake.Types (Dep(..))
 import GHC.ParMake.Util (Verbosity, debug', defaultOutputHooks, runProcess)
 
 
@@ -53,15 +61,76 @@ getModuleDeps :: Verbosity
               -> FilePath
               -> [String]
               -> [FilePath]
-              -> IO [(String, String)]
+              -> IO [Dep]
 getModuleDeps v ghcPath ghcArgs files =
   withSystemTempDirectory "ghc-parmake" $ \tmpDir -> do
-    let tmpFile = tmpDir </> "depends.mk"
-    let ghcArgs' = files ++ ("-M":"-dep-makefile":tmpFile:ghcArgs)
-    debug' v $ "Running compiler with -M to get module deps: "
-               ++ ghcPath ++ " " ++ show ghcArgs'
-    exitCode <- runProcess defaultOutputHooks Nothing ghcPath ghcArgs'
-    if exitCode == ExitSuccess
-      then (catMaybes . map parseLine . trimLines . lines) <$>
-           (readFile tmpFile)
-      else error "GHC.ParMake.Parse.getModuleDeps: ghc -M failed"
+
+    let tmpFileInternal = tmpDir </> "depends.internal.mk"
+        tmpFileExternal = tmpDir </> "depends.external.mk"
+
+    let ghcArgsInternal = files ++ ("-M":"-dep-makefile":tmpFileInternal:ghcArgs)
+        ghcArgsExternal = files ++ ("-M":"-dep-makefile":tmpFileExternal:"-include-pkg-deps":ghcArgs)
+
+    -- Get all dependencies in this package
+    let getInternalMakeDeps = do
+          debug' v $ "Running compiler with -M to get internal module deps: "
+                     ++ ghcPath ++ " " ++ show ghcArgsInternal
+          failOnError <$> runProcess defaultOutputHooks Nothing ghcPath ghcArgsInternal
+          parseDepsFromFile tmpFileInternal
+
+    -- Pass -include-pkg-deps to also depend on external dependencies
+    let getAllMakeDeps = do
+          debug' v $ "Running compiler with -M -include-pkg-deps to also get external module deps: "
+                     ++ ghcPath ++ " " ++ show ghcArgsExternal
+          failOnError <$> runProcess defaultOutputHooks Nothing ghcPath ghcArgsExternal
+          parseDepsFromFile tmpFileExternal
+
+    -- The two ghc -M are mainly CPU-bound. Run them in parallel.
+    [internalMakeDeps, allMakeDeps] <- parallelIO [ getInternalMakeDeps
+                                                  , getAllMakeDeps ]
+
+    -- Put internal and internal + external deps together
+    let depsIntAll = mergeValues (groupByTarget internalMakeDeps)
+                                 (groupByTarget allMakeDeps)
+
+    -- External deps are (all - internal) ones.
+    return [ Dep target int (intExt `diff` int) | (target, (int, intExt)) <- Map.toList depsIntAll ]
+  where
+    failOnError ExitSuccess     = ()
+    failOnError (ExitFailure n) = error $ "ghc-parmake: ghc -M exited with status "
+                                          ++ show n
+
+    parseDepsFromFile :: FilePath -> IO [(String, String)]
+    parseDepsFromFile file = catMaybes . map parseLine . trimLines . lines
+                             <$> readFile file
+
+-- * Helpers
+
+-- | Fast list difference. Uses `Set.difference`, but preserves order.
+diff :: (Ord a) => [a] -> [a] -> [a]
+xs `diff` ys = filter (`Set.member` diffSet) xs
+  where
+    diffSet = Set.fromList xs `Set.difference` Set.fromList ys
+
+-- | Runs the IO actions in parallel, and waits until all are finished.
+parallelIO :: [IO a] -> IO [a]
+parallelIO ios = do
+  mvars <- forM ios $ \io -> do m <- newEmptyMVar
+                                _ <- forkIO $ io >>= putMVar m
+                                return m
+  mapM readMVar mvars
+
+-- | Groups a list of (targets, dependencies) by the targets.
+groupByTarget :: (Ord target) => [(target, dep)] -> Map target [dep]
+groupByTarget deps = Map.fromListWith (++) [ (t, [d]) | (t, d) <- deps ]
+
+-- | Merges two maps that have the same keys.
+mergeValues :: (Ord k) => Map k [a] -> Map k [b] -> Map k ([a], [b])
+mergeValues m1 m2 = Map.unionWith (\(a,b) (x,y) -> (a ++ x, b ++ y))
+                                  (fmap (, []) m1)
+                                  (fmap ([], ) m2)
+
+-- | Converts a list of (targets, dependencies) to a `Dep` list
+-- with no external dependencies.
+depsListToDeps :: [(FilePath, FilePath)] -> [Dep]
+depsListToDeps l = [ Dep t ds [] | (t, ds) <- Map.toList (groupByTarget l) ]

--- a/src/GHC/ParMake/Parse.hs
+++ b/src/GHC/ParMake/Parse.hs
@@ -64,4 +64,4 @@ getModuleDeps v ghcPath ghcArgs files =
     if exitCode == ExitSuccess
       then (catMaybes . map parseLine . trimLines . lines) <$>
            (readFile tmpFile)
-      else return []
+      else error "GHC.ParMake.Parse.getModuleDeps: ghc -M failed"

--- a/src/GHC/ParMake/Types.hs
+++ b/src/GHC/ParMake/Types.hs
@@ -1,0 +1,11 @@
+module GHC.ParMake.Types
+       ( Dep(..) )
+       where
+
+-- | A dependency as expressed by ghc -M output
+data Dep = Dep
+  { depTarget   :: FilePath   -- ^ The target file
+  , depInternal :: [FilePath] -- ^ Dependencies in our build
+  , depExternal :: [FilePath] -- ^ External dependencies as mentioned by ghc -M -include-pkg-deps
+                              --   (minus the internal ones)
+  } deriving (Eq, Ord, Show)

--- a/src/GHC/ParMake/Util.hs
+++ b/src/GHC/ParMake/Util.hs
@@ -5,6 +5,7 @@ module GHC.ParMake.Util (runProcess, upToDateCheck
                         , defaultOutputHooks, OutputHooks(..)
                         , warn, notice, info, debug
                         , warn', notice', noticeRaw, info', debug'
+                        , Dep(..)
                         , Verbosity, intToVerbosity
                         , silent, normal, verbose, deafening)
        where
@@ -19,6 +20,15 @@ import System.IO ( hClose, hGetContents, hFlush, hPutStr, hPutStrLn
 import System.Process (runInteractiveProcess, waitForProcess)
 
 import GHC.ParMake.Common (andM)
+
+
+-- | A dependency as expressed by ghc -M output
+data Dep = Dep
+  { depTarget :: FilePath  -- ^ The target file
+  , internal :: [FilePath] -- ^ Dependencies in our build
+  , external :: [FilePath] -- ^ External dependencies as mentioned by ghc -M -include-pkg-deps
+                           --   (minus the internal ones)
+  } deriving (Eq, Ord, Show)
 
 -- Copied from Distribution.Verbosity.
 data Verbosity = Silent | Normal | Verbose | Deafening

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -19,6 +19,7 @@ import Test.Framework.Providers.HUnit (testCase)
 import qualified GHC.ParMake.BuildPlan as BuildPlan
 import GHC.ParMake.BuildPlan (TargetId)
 import GHC.ParMake.Common (appendMap, uniq)
+import GHC.ParMake.Parse (depsListToDeps)
 
 ------------------------------------------------------------------------
 -- Input data generation for QuickCheck.
@@ -67,7 +68,7 @@ arbitraryName = (listOf . elements $ ['A'..'Z'] ++ ['a'..'z'] ++ ['0'..'9'])
 pMarkCompleted :: DepsList -> Bool
 pMarkCompleted (DepsList []) = True
 pMarkCompleted (DepsList  l) =
-  let plan = BuildPlan.new l
+  let plan = BuildPlan.new (depsListToDeps l)
       target = head . BuildPlan.ready $ plan
       plan' = BuildPlan.markReadyAsBuilding plan
       plan'' = BuildPlan.markCompleted plan' target
@@ -75,7 +76,7 @@ pMarkCompleted (DepsList  l) =
 
 pCompile :: DepsList -> Bool
 pCompile (DepsList []) = True
-pCompile (DepsList l) = go $ BuildPlan.new l
+pCompile (DepsList l) = go $ BuildPlan.new (depsListToDeps l)
   where
     go plan = if null rdy then check plan else go plan''
       where


### PR DESCRIPTION
Here we have some improvements that finally make parmake build _correctly_ even when external packages change.

While some time ago I thought this would only be possible with external knowledge from cabal or similar (as implemented in my patch to [skip all Make-style time mchecks building when a SKIP_TIME_CHECK environment variable is set](https://github.com/nh2/ghc-parmake/commit/55678b15fa82bbb3ebc18dcca1e3662a7e26d793)), I recently found the [`ghc -M -include-pkg-deps`](http://www.haskell.org/ghc/docs/7.6.3/html/users_guide/separate-compilation.html#makefile-dependencies) option, that allows us to get external `.hi` dependencies as well.
